### PR TITLE
Correcting typo on VM template

### DIFF
--- a/polls/templates/vm.html
+++ b/polls/templates/vm.html
@@ -66,7 +66,7 @@
             <p><b>Uptime:</b> {{ dom_uptime }} (Min)</p>
           </div>
           <hr>
-          <li>Techniacl Details</li><br>
+          <li>Technical Details</li><br>
           <div class="pagination-centered">
             <p><b>VCPU:</b> {{ dom_info.0 }} (Usage: {{ cpu_usage }}%)</p>
             <p><b>RAM:</b> {{ dom_info.1 }} MB (Usage: {{ mem_usage.1 }}%)</p>


### PR DESCRIPTION
There was a typo on the VM information page.
