### PR TITLE
'connect' -> 'connected' on the dashboard

### DIFF
--- a/polls/templates/dashboard.html
+++ b/polls/templates/dashboard.html
@@ -31,7 +31,7 @@
           <tr>
             <td>{{ forloop.counter }}</td>
             <td>{{ value.1 }} (<strong>{{ key }}</strong>)</td>
-            <td>{% ifequal value.2 1 %}<font color="green">connect</font>{% else %}<font color="red">not connect ({{ value.2 }})</font>{% endifequal %}</td>
+            <td>{% ifequal value.2 1 %}<font color="green">connected</font>{% else %}<font color="red">not connected ({{ value.2 }})</font>{% endifequal %}</td>
             <td style="width: 80px;">
               {% ifequal value.2 1 %}
               <div class="btn-group">


### PR DESCRIPTION
I got confused when I saw `connect` and thought that I had to click it to connect to the host.

I think the proper term in English is `connected`.
