### PR TITLE
Found in Fedora 17 the new VMs were defaulting to qemu-system-x86_64 due to a path change.

### DIFF
--- a/newvm/views.py
+++ b/newvm/views.py
@@ -39,6 +39,8 @@ def newvm(request, host_id):
             emulator = '/usr/libexec/qemu-kvm'
         elif re.findall('/usr/bin/kvm', conn.getCapabilities()):
             emulator = '/usr/bin/kvm'
+        elif re.findall('/usr/bin/qemu-kvm', conn.getCapabilities()):
+            emulator = '/usr/bin/qemu-kvm'            
         else:
             emulator = '/usr/bin/qemu-system-x86_64'
 


### PR DESCRIPTION
In this release, the KVM binary is:
/usr/bin/qemu-kvm
