### PR TITLE
Fixed default return value of vds_get_media() method

### DIFF
--- a/webvirtmgr/server.py
+++ b/webvirtmgr/server.py
@@ -871,6 +871,7 @@ class ConnServer(object):
                         return media, media
                 else:
                     return None, None
+            return None, None
 
     def vds_set_vnc_passwd(self, vname, passwd):
         """


### PR DESCRIPTION
Hello,

I fixed default return value of vds_get_media() method in server.py. In my installation and with VMs I have previously created, it's cause error 500 when I try to access to overview page of this VM.

Thank you for this great software.

Benjamin
