### PR TITLE
Instance.vnc_passwd cant be true fix

### DIFF
--- a/instance/models.py
+++ b/instance/models.py
@@ -26,7 +26,7 @@ class Flavor(models.Model):
 class Instance(models.Model):
     host = models.ForeignKey(Host)
     vname = models.CharField(max_length=255)
-    vnc_passwd = models.CharField(max_length=255)
+    vnc_passwd = models.CharField(max_length=255, null=True)
 
     def __unicode__(self):
         return self.vname


### PR DESCRIPTION
Quick fix in case of first (within VM life) console open try when exception of "Instance.vnc_passwd can't be Null" occurs.
