### PR TITLE
for rbd devices, evaluate name field for graceful error message

### DIFF
--- a/vrtManager/instance.py
+++ b/vrtManager/instance.py
@@ -146,7 +146,7 @@ class wvmInstance(wvmConnect):
                 device = disk.xpathEval('@device')[0].content
                 if device == 'disk':
                     dev = disk.xpathEval('target/@dev')[0].content
-                    file = disk.xpathEval('source/@file|source/@dev')[0].content
+                    file = disk.xpathEval('source/@file|source/@dev|source/@name')[0].content
                     vol = self.get_volume_by_path(file)
                     volume = vol.name()
                     stg = vol.storagePoolLookupByVolume()


### PR DESCRIPTION
When using rbd devices such as:

```
<disk type='network' device='disk'>
  <driver name='qemu' type='raw'/>
  <auth username='libvirt'>
    <secret type='ceph' uuid='dc28392e-a277-4077-80ed-07040f5daffb'/>
  </auth>
  <source protocol='rbd' name='data/controller'>
    <host name='compute01' port='6789'/>
    <host name='192.168.1.2' port='6789'/>
  </source>
  <target dev='vdz' bus='virtio'/>
  <address type='pci' domain='0x0000' bus='0x00' slot='0x04' function='0x0'/>
</disk>
```

Viewing the instance configuration causes a 500, as disk.xpathEval('source/@file|source/@dev')[0] throws an index error as one might expect. If we use the name field to lookup the storage volume, the instance view is displayed, however a graceful error is displayed:

https://drive.google.com/file/d/0B9DbsE2BbZ7uQzlrSEZBbG1UUnM/edit?usp=sharing

Signed-off-by: Tyler Baker tyler.baker@linaro.org
