### PR TITLE
add a descriptive title to delete instance view

### DIFF
--- a/templates/instance.html
+++ b/templates/instance.html
@@ -283,7 +283,7 @@
             <div class="modal-content">
                 <div class="modal-header">
                     <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                    <h4 class="modal-title">{% trans "Undefined Server" %}</h4>
+                    <h4 class="modal-title">{% trans "Delete" %} '{{ vname }}'</h4>
                 </div>
                 <div class="modal-body">
                     <p>{% trans "Delete HDD image?" %}</p>


### PR DESCRIPTION
When the delete view is displayed, the title was "Undefined Server" which is confusing. This patch will display "Delete 'VM Name'" similar to the migrate view.

https://drive.google.com/file/d/0B9DbsE2BbZ7uVEVwLUJnVXRBb0E/edit?usp=sharing

Signed-off-by: Tyler Baker tyler.baker@linaro.org
