### PR TITLE
better error handling when locating storage devices

### DIFF
--- a/vrtManager/instance.py
+++ b/vrtManager/instance.py
@@ -161,22 +161,37 @@ class wvmInstance(wvmConnect):
     def get_disk_device(self):
         def disks(ctx):
             result = []
+            dev = None
+            volume = None
+            storage = None
+            file = None
             for disk in ctx.xpathEval('/domain/devices/disk'):
                 device = disk.xpathEval('@device')[0].content
                 if device == 'disk':
-                    dev = disk.xpathEval('target/@dev')[0].content
-                    file = disk.xpathEval('source/@file|source/@dev|source/@name')[0].content
-                    vol = self.get_volume_by_path(file)
-                    volume = vol.name()
-                    stg = vol.storagePoolLookupByVolume()
-                    storage = stg.name()
-                    result.append({'dev': dev, 'image': volume, 'storage': storage, 'path': file})
+                    try:
+                        dev = disk.xpathEval('target/@dev')[0].content
+                        file = disk.xpathEval('source/@file|source/@dev|source/@name')[0].content
+                        try:
+                            vol = self.get_volume_by_path(file)
+                            volume = vol.name()
+                            stg = vol.storagePoolLookupByVolume()
+                            storage = stg.name()
+                        except libvirtError:
+                            volume = file
+                    except:
+                        pass
+                    finally:
+                        result.append({'dev': dev, 'image': volume, 'storage': storage, 'path': file})
             return result
         return util.get_xml_path(self._XMLDesc(0), func=disks)
 
     def get_media_device(self):
         def disks(ctx):
             result = []
+            dev = None
+            volume = None
+            storage = None
+            file = None
             for media in ctx.xpathEval('/domain/devices/disk'):
                 device = media.xpathEval('@device')[0].content
                 if device == 'cdrom':
@@ -190,10 +205,10 @@ class wvmInstance(wvmConnect):
                             storage = stg.name()
                         except libvirtError:
                             volume = file
-                            storage = None
-                        result.append({'dev': dev, 'image': volume, 'storage': storage, 'path': file})
                     except:
                         pass
+                    finally:
+                        result.append({'dev': dev, 'image': volume, 'storage': storage, 'path': file})
             return result
         return util.get_xml_path(self._XMLDesc(0), func=disks)
 


### PR DESCRIPTION
instance/views.py:

when using network storage devices, such as rbd, conn.get_disk_device() generates a libvirtError exception as there is no local path for the device. the issue here is that once this exception is generated, any functions after conn.get_disk_device() never will be called, resulting in data fields not being populated.

for example:

a graceful error is displayed, however the network, media, vcpu, memory, xml, etc.. data fields are never populated, as the functions were never called due to the exception.
https://docs.google.com/file/d/0B9DbsE2BbZ7uQnc3VU5udEZLTDg/edit
https://docs.google.com/file/d/0B9DbsE2BbZ7ualFhQWtsOWZieHc/edit
https://drive.google.com/file/d/0B9DbsE2BbZ7uX2VoNzlPTHUxdkE/edit

the solution purposed here is the handle theses errors in the get_disk_device, and get_media_device to ensure we populate all data fields.

after the patch is applied:

https://docs.google.com/file/d/0B9DbsE2BbZ7uR2JBZGtLeEUzRDg/edit
https://docs.google.com/file/d/0B9DbsE2BbZ7ucmd6LXFTSDhBLWc/edit
https://docs.google.com/file/d/0B9DbsE2BbZ7uLUlBejBGbFkwOGs/edit?usp=drive_web

Signed-off-by: Tyler Baker tyler.baker@linaro.org
