### PR TITLE
Deduplicating requirements files

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,5 @@
-django==1.5.5
+-r requirements.txt
+
 django-jenkins==0.14.1
 pyflakes==0.7.3
 pylint==1.1.0


### PR DESCRIPTION
Completely cosmetic. Sourcing the non-dev version of the `requirements.txt` so two lists don't have to be maintained.
