### PR TITLE
Fixes UUID: UUID's are 36 Chars long, not 12...

### DIFF
--- a/instance/models.py
+++ b/instance/models.py
@@ -4,8 +4,8 @@ from servers.models import Compute
 
 class Instance(models.Model):
     compute = models.ForeignKey(Compute)
-    name = models.CharField(max_length=12)
-    uuid = models.CharField(max_length=12)
+    name = models.CharField(max_length=20)
+    uuid = models.CharField(max_length=36)
 #    display_name = models.CharField(max_length=50)
 #    display_description = models.CharField(max_length=255)
 


### PR DESCRIPTION
The current implementation won't work against databases other than sqlite3 since the model had an issue with uuid's (they are 36 chars long)
Sqlite won't fail since there are no varchars only strings without a length.
