### PR TITLE
rbd: ensure dev_file and dev_bus are never referenced before they are se...

### DIFF
--- a/vrtManager/instance.py
+++ b/vrtManager/instance.py
@@ -297,6 +297,8 @@ class wvmInstance(wvmConnect):
         for disk in tree.findall('devices/disk'):
             if disk.get('device') == 'disk':
                 for elm in disk:
+                    dev_file = None
+                    dev_bus = None
                     if elm.tag == 'source':
                         if elm.get('file'):
                             dev_file = elm.get('file')
@@ -304,7 +306,8 @@ class wvmInstance(wvmConnect):
                             dev_file = elm.get('dev')
                     if elm.tag == 'target':
                             dev_bus = elm.get('dev')
-                devices.append([dev_file, dev_bus])
+                if (dev_file and dev_bus) is not None:
+                    devices.append([dev_file, dev_bus])
         for dev in devices:
             rd_use_ago = self.instance.blockStats(dev[0])[1]
             wr_use_ago = self.instance.blockStats(dev[0])[3]


### PR DESCRIPTION
When using rbd with qemu: elm.tag('file') and elm('dev') will not return true. So the variables dev_file and dev_bus will be referenced before they are assigned. This results is the instance graphing view stops functioning.

```
<disk type='network' device='disk'>
  <driver name='qemu' type='raw'/>
  <auth username='libvirt'>
    <secret type='ceph' usage='client.libvirt secret'/>
  </auth>
  <source protocol='rbd' name='data/storage'>
    <host name='compute01' port='6789'/>
    <host name='192.168.1.2' port='6789'/>
  </source>
  <target dev='vdz' bus='virtio'/>
  <alias name='virtio-disk25'/>
  <address type='pci' domain='0x0000' bus='0x00' slot='0x04' function='0x0'/>
</disk>
```

This patch will initialize the variables and check that dev_file and dev_bus are set to a value other than None before they are used.

This fixes this issue:

https://github.com/retspen/webvirtmgr/issues/281
