### PR TITLE
enable blockstats for network disks

### DIFF
--- a/vrtManager/instance.py
+++ b/vrtManager/instance.py
@@ -298,8 +298,12 @@ class wvmInstance(wvmConnect):
             if disk.get('device') == 'disk':
                 dev_file = None
                 dev_bus = None
+                network_disk = True
                 for elm in disk:
                     if elm.tag == 'source':
+                        if elm.get('protocol'):
+                            dev_file = elm.get('protocol')
+                            network_disk = True
                         if elm.get('file'):
                             dev_file = elm.get('file')
                         if elm.get('dev'):
@@ -307,6 +311,8 @@ class wvmInstance(wvmConnect):
                     if elm.tag == 'target':
                             dev_bus = elm.get('dev')
                 if (dev_file and dev_bus) is not None:
+                    if network_disk:
+                        dev_file = dev_bus
                     devices.append([dev_file, dev_bus])
         for dev in devices:
             rd_use_ago = self.instance.blockStats(dev[0])[1]


### PR DESCRIPTION
Reading through the libvirt API I found that it is possible to retrieve block stats from network disks.

'dev_file' is assumed to be the path to the virtual hard disk which is gathered from the source element. However, network disks do not have a 'dev' or 'file' attribute as documented here:

http://libvirt.org/formatdomain.html#elementsDisks

Libvirt:blockStats will not only accept a path to the virtual disk, but also a target block device such as 'vdz'. This change set detects a network disk, and set dev_file = dev_bus in only that case.

I've tested this change locally, and disk usage is shown for both virtual machines with physical virtual hard disks, and network (rbd) disks! It would be nice if anyone else using a network disk to test if this and validate that is working for them as well.

Here is a picture of disk usage reporting for a network disk:

![screen shot 2014-04-28 at 5 54 44 pm](https://cloud.githubusercontent.com/assets/1061011/2825057/9cca8392-cf41-11e3-8a14-7d9345e8b497.png)
