### PR TITLE
console: add option to launch telnet session

### DIFF
--- a/instance/views.py
+++ b/instance/views.py
@@ -473,6 +473,7 @@ def instance(request, host_id, vname):
         memory_range = [256, 512, 1024, 2048, 4096, 6144, 8192, 16384]
         memory_host = conn.get_max_memory()
         vcpu_host = len(vcpu_range)
+        telnet_port = conn.get_telnet_port()
         vnc_port = conn.get_vnc()
         vnc_keymap = conn.get_vnc_keymap
         snapshots = sorted(conn.get_snapshot(), reverse=True)

--- a/templates/instance.html
+++ b/templates/instance.html
@@ -166,18 +166,30 @@
             </div>
             <div class="tab-pane" id="access" style="margin-top: 20px">
                 <ul class="nav nav-tabs ">
-                    <li class="active"><a href="#console" data-toggle="tab">{% trans "Console" %}</a></li>
+                    <li class="active"><a href="#vnc_console" data-toggle="tab">{% trans "VNC Console" %}</a></li>
                     <li><a href="#vnc_pass" data-toggle="tab">{% trans "VNC Password" %}</a></li>
                     <li><a href="#vnc_keymap" data-toggle="tab">{% trans "VNC Keymap" %}</a></li>
+                    {% if telnet_port %}
+                        <li><a href="#telnet_console" data-toggle="tab">{% trans "Telnet Console" %}</a></li>
+                    {% endif %}
 
                 </ul>
                 <div class="tab-content">
-                    <div class="tab-pane tab-inst active" id="console">
+                    <div class="tab-pane tab-inst active" id="vnc_console">
                         <p>{% trans "This action open new window with console VNC connection to your instance." %}</p>
                         {% ifequal status 5 %}
                             <button class="btn btn-primary btn-lg pull-right disabled">{% trans "Console" %}</button>
                         {% else %}
                             <a href="#" class="btn btn-primary btn-lg pull-right" title="VNC Port: {{ vnc_port }}" onclick="open_vnc()">{% trans "Console" %}</a>
+                        {% endifequal %}
+                        <div class="clearfix"></div>
+                    </div>
+                    <div class="tab-pane tab-inst" id="telnet_console">
+                        <p>{% trans "This action open new window with console Telnet connection to your instance." %}</p>
+                        {% ifequal status 5 %}
+                            <button class="btn btn-primary btn-lg pull-right disabled">{% trans "Console" %}</button>
+                        {% else %}
+                            <a href="telnet://{{ compute.hostname }}:{{ telnet_port }}" class="btn btn-primary btn-lg pull-right" title="Telnet Port: {{ telnet_port }}">{% trans "Console" %}</a>
                         {% endifequal %}
                         <div class="clearfix"></div>
                     </div>

--- a/vrtManager/instance.py
+++ b/vrtManager/instance.py
@@ -230,11 +230,6 @@ class wvmInstance(wvmConnect):
             return result
         return util.get_xml_path(self._XMLDesc(0), func=disks)
 
-    def get_vnc(self):
-        vnc = util.get_xml_path(self._XMLDesc(0),
-                                "/domain/devices/graphics[@type='vnc']/@port")
-        return vnc
-
     def mount_iso(self, image):
         storages = self.get_storages()
         for storage in storages:
@@ -340,6 +335,27 @@ class wvmInstance(wvmConnect):
             tx_diff_usage = (tx_use_now - tx_use_ago) * 8
             dev_usage.append({'dev': i, 'rx': rx_diff_usage, 'tx': tx_diff_usage})
         return dev_usage
+
+    def get_telnet_port(self):
+        telnet_port = None
+        service_port = None
+        tree = ElementTree.fromstring(self._XMLDesc(0))
+        for console in tree.findall('devices/console'):
+            if console.get('type') == 'tcp':
+                for elm in console:
+                    if elm.tag == 'source':
+                        if elm.get('service'):
+                            service_port = elm.get('service')
+                    if elm.tag == 'protocol':
+                        if elm.get('type') == 'telnet':
+                            if service_port is not None:
+                                telnet_port = service_port
+        return telnet_port
+
+    def get_vnc(self):
+        vnc = util.get_xml_path(self._XMLDesc(0),
+                                "/domain/devices/graphics[@type='vnc']/@port")
+        return vnc
 
     def get_vnc_passwd(self):
         return util.get_xml_path(self._XMLDesc(VIR_DOMAIN_XML_SECURE),


### PR DESCRIPTION
Over the coming months I would like to add supporting features to webvirtmgr needed for ARM KVM hosts. This is the first piece needed to make webvirtmgr useful with ARM hosts. As of right now, there is no video/graphic devices supported on ARM guests, and so VNC cannot be used for console. The best solution to control the virtual machine is to redirect the serial console over telnet.

```
<serial type='tcp'>
  <source mode='bind' host='0.0.0.0' service='4555'/>
  <protocol type='telnet'/>
  <target port='0'/>
  <alias name='serial0'/>
</serial>
<console type='tcp'>
  <source mode='bind' host='0.0.0.0' service='4555'/>
  <protocol type='telnet'/>
  <target type='serial' port='0'/>
  <alias name='serial0'/>
</console>
```

This change adds the option to launch a telnet console session if one exists.

Here is a quick demo of this feature:

https://docs.google.com/file/d/0B9DbsE2BbZ7uWmNnTHQxYW1IZVE/edit
