### PR TITLE
Make the viewXMLform look almost identical to viewXMLpre, along with monospaced font.

### DIFF
--- a/templates/instance.html
+++ b/templates/instance.html
@@ -461,7 +461,7 @@
                             {% endifequal %}
                         </div>
                         <form id="viewXMLform" class="form-horizontal" method="post" role="form" style="display: none;">{% csrf_token %}
-                            <textarea style="margin-bottom: 20px;" class="form-control" rows="17" name="inst_xml">{{ inst_xml }}</textarea>
+                            <textarea id="xmltextarea" name="inst_xml">{{ inst_xml }}</textarea>
                             <button type="button" class="btn btn-lg btn-default" onclick="javascript:$('#viewXMLpre').show();$('#viewXMLform').hide();">{% trans "Close" %}</button>
                             <button type="submit" class="btn btn-lg btn-danger pull-right" name="change_xml">{% trans "Save" %}</button>
                         </form>

--- a/webvirtmgr/static/css/webvirtmgr.css
+++ b/webvirtmgr/static/css/webvirtmgr.css
@@ -147,3 +147,14 @@ p {
     border: 1px solid #eee;
     border-top: 0;
 }
+#xmltextarea { 
+    font-family: Monaco, Menlo, Consolas, "Courier New", monospace; 
+    font-size: 12px; 
+    width: 100%; 
+    height: 340px; 
+    padding: 9.5px 0px 0px 9.5px; 
+    margin-bottom: 10px; 
+    background-color: rgb(245, 245, 245); 
+    border: 1px solid rgb(204, 204, 204); 
+    border-radius: 4px;                                                             
+}                                                                                   


### PR DESCRIPTION
There is still a bug where the padding of the textarea affects the scrollbar as well as the text itself, making the scrollbar padded from the top of the textarea, but this is at least better than before.

Screenshots:
![before](https://cloud.githubusercontent.com/assets/538013/2939557/fe25c932-d94e-11e3-8ad9-1463209fc56d.png)
![after](https://cloud.githubusercontent.com/assets/538013/2939556/fe10b222-d94e-11e3-9335-080960916ddd.png)
