### PR TITLE
Don't show shutdown VMs on the infrastructure page

### DIFF
--- a/vrtManager/connection.py
+++ b/vrtManager/connection.py
@@ -140,7 +140,9 @@ class wvmConnect(object):
                 vcpu = cur_vcpu
             else:
                 vcpu = util.get_xml_path(dom.XMLDesc(0), "/domain/vcpu")
-            vname[dom.name()] = (dom.info()[0], vcpu, mem, mem_usage)
+            # Only show running or suspended VMs.
+            if dom.info()[0] != 5:
+                vname[dom.name()] = (dom.info()[0], vcpu, mem, mem_usage)
         return vname
 
     def close(self):


### PR DESCRIPTION
Hi,

This likely isn't a proper fix, but just raising this anyway.   My setup is that I have 12 blades in an enclosure, and there are two SANs which disk pools are exposed via iSCSI.  For the purpose of live migration, VM configuration is kept spread between the 12 hosts, which means on the infrastructure page, it shows multiple copies of the same VM, running on one host, and shutdown on every other host that configuration is found.

This doesn't serve too well when there are an upward of 100 VMs to show, so what I want to be able to do is hide all powered off VMs, showing only running or suspended in this view.  This gives me a better summary view of which VMs are running on each host and the spread among them when it comes to provisioning more servers.

This PR shows the quick fix I've done to get this aspect of webvirtmgr much more pleasant.  What instead may need to be done is move it to a local_settings parameter, so people can opt-in to this behaviour only if they choose to.
