### PR TITLE
Fix spelling mistake in 'instance'

### DIFF
--- a/locale/ru/LC_MESSAGES/django.po
+++ b/locale/ru/LC_MESSAGES/django.po
@@ -508,7 +508,8 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: templates/infrastructure.html:49 templates/instances.html:42
+#: templates/infrastructure.html:49 templates/instance.html:125
+#: templates/instances.html:42
 msgid "Shutoff"
 msgstr ""
 
@@ -596,10 +597,6 @@ msgstr ""
 #: templates/instance.html:120 templates/network.html:53
 #: templates/storage.html:64
 msgid "Disable"
-msgstr ""
-
-#: templates/instance.html:125
-msgid "Shuttoff"
 msgstr ""
 
 #: templates/instance.html:137

--- a/locale/zh_CN/LC_MESSAGES/django.po
+++ b/locale/zh_CN/LC_MESSAGES/django.po
@@ -509,7 +509,8 @@ msgstr "运行"
 msgid "Suspend"
 msgstr "暂停"
 
-#: templates/infrastructure.html:49 templates/instances.html:42
+#: templates/infrastructure.html:49 templates/instance.html:125
+#: templates/instances.html:42
 msgid "Shutoff"
 msgstr "关闭"
 
@@ -599,10 +600,6 @@ msgstr "启用"
 #: templates/storage.html:64
 msgid "Disable"
 msgstr "禁用"
-
-#: templates/instance.html:125
-msgid "Shuttoff"
-msgstr "关闭"
 
 #: templates/instance.html:137
 msgid "Technical Details"

--- a/templates/instance.html
+++ b/templates/instance.html
@@ -39,7 +39,7 @@
                                             {% ifequal has_managed_save_image 1 %}
                                                 "text-warning">{% trans "Saved" %}
                                             {% else %}
-                                                "text-danger">{% trans "Shuttoff" %}
+                                                "text-danger">{% trans "Shutoff" %}
                                             {% endifequal %}
                                         {% endifequal %}
                                         {% ifequal status 1 %}"text-success">{% trans "Running" %}{% endifequal %}


### PR DESCRIPTION
Spelling mistake noted in `/instance` page.

I'm not familiar with how django.po files work, you'll have to check my change here.  And I see there is a binary file `locale/zh_CN/LC_MESSAGES/django.mo` that may have this mispelling in that I'm not sure how to update.
