### PR TITLE
Add translated titles to action buttons on servers page

### DIFF
--- a/locale/ru/LC_MESSAGES/django.po
+++ b/locale/ru/LC_MESSAGES/django.po
@@ -376,17 +376,18 @@ msgstr ""
 #: templates/create.html:152 templates/create.html.py:154
 #: templates/create.html:161 templates/create.html.py:257
 #: templates/create.html:259 templates/networks.html:9
-#: templates/networks.html.py:116 templates/sidebar.html:15
-#: templates/storage.html:237 templates/storages.html:9
-#: templates/storages.html.py:106 templates/storages.html:133
-#: templates/storages.html.py:155
+#: templates/networks.html.py:116 templates/servers.html:75
+#: templates/sidebar.html:15 templates/storage.html:237
+#: templates/storages.html:9 templates/storages.html.py:106
+#: templates/storages.html:133 templates/storages.html.py:155
 msgid "Create"
 msgstr ""
 
 #: templates/create.html:166 templates/instance.html:52
 #: templates/instance.html.py:281 templates/network.html:42
-#: templates/snapshot.html:57 templates/storage.html:53
-#: templates/storage.html.py:99 templates/storage.html:186
+#: templates/servers.html:112 templates/snapshot.html:57
+#: templates/storage.html:53 templates/storage.html.py:99
+#: templates/storage.html:186
 msgid "Delete"
 msgstr ""
 
@@ -423,6 +424,7 @@ msgid "Add"
 msgstr ""
 
 #: templates/hostdetail.html:4 templates/hostdetail.html.py:21
+#: templates/servers.html:84
 msgid "Overview"
 msgstr ""
 
@@ -560,7 +562,7 @@ msgid "Statistics"
 msgstr ""
 
 #: templates/instance.html:71 templates/instance.html.py:73
-#: templates/instance.html:365
+#: templates/instance.html:365 templates/servers.html:109
 msgid "Edit"
 msgstr ""
 
@@ -701,7 +703,7 @@ msgid "Save"
 msgstr ""
 
 #: templates/instances.html:4 templates/instances.html.py:13
-#: templates/sidebar.html:12
+#: templates/servers.html:72 templates/sidebar.html:12
 msgid "Instances"
 msgstr ""
 
@@ -887,12 +889,12 @@ msgstr ""
 msgid "Need create ssh authorization key"
 msgstr ""
 
-#: templates/sidebar.html:18 templates/storages.html:3
-#: templates/storages.html.py:10
+#: templates/servers.html:78 templates/sidebar.html:18
+#: templates/storages.html:3 templates/storages.html.py:10
 msgid "Storages"
 msgstr ""
 
-#: templates/sidebar.html:21
+#: templates/servers.html:81 templates/sidebar.html:21
 msgid "Networks"
 msgstr ""
 

--- a/locale/zh_CN/LC_MESSAGES/django.po
+++ b/locale/zh_CN/LC_MESSAGES/django.po
@@ -375,17 +375,18 @@ msgstr "关闭"
 #: templates/create.html:152 templates/create.html.py:154
 #: templates/create.html:161 templates/create.html.py:257
 #: templates/create.html:259 templates/networks.html:9
-#: templates/networks.html.py:116 templates/sidebar.html:15
-#: templates/storage.html:237 templates/storages.html:9
-#: templates/storages.html.py:106 templates/storages.html:133
-#: templates/storages.html.py:155
+#: templates/networks.html.py:116 templates/servers.html:75
+#: templates/sidebar.html:15 templates/storage.html:237
+#: templates/storages.html:9 templates/storages.html.py:106
+#: templates/storages.html:133 templates/storages.html.py:155
 msgid "Create"
 msgstr "创建"
 
 #: templates/create.html:166 templates/instance.html:52
 #: templates/instance.html.py:281 templates/network.html:42
-#: templates/snapshot.html:57 templates/storage.html:53
-#: templates/storage.html.py:99 templates/storage.html:186
+#: templates/servers.html:112 templates/snapshot.html:57
+#: templates/storage.html:53 templates/storage.html.py:99
+#: templates/storage.html:186
 msgid "Delete"
 msgstr "删除"
 
@@ -422,6 +423,7 @@ msgid "Add"
 msgstr "添加"
 
 #: templates/hostdetail.html:4 templates/hostdetail.html.py:21
+#: templates/servers.html:84
 msgid "Overview"
 msgstr "概览"
 
@@ -561,7 +563,7 @@ msgid "Statistics"
 msgstr "统计"
 
 #: templates/instance.html:71 templates/instance.html.py:73
-#: templates/instance.html:365
+#: templates/instance.html:365 templates/servers.html:109
 msgid "Edit"
 msgstr "编辑"
 
@@ -705,7 +707,7 @@ msgid "Save"
 msgstr "保存"
 
 #: templates/instances.html:4 templates/instances.html.py:13
-#: templates/sidebar.html:12
+#: templates/servers.html:72 templates/sidebar.html:12
 msgid "Instances"
 msgstr "虚机实例"
 
@@ -891,12 +893,12 @@ msgstr "********"
 msgid "Need create ssh authorization key"
 msgstr "需要创建SSH认证密钥"
 
-#: templates/sidebar.html:18 templates/storages.html:3
-#: templates/storages.html.py:10
+#: templates/servers.html:78 templates/sidebar.html:18
+#: templates/storages.html:3 templates/storages.html.py:10
 msgid "Storages"
 msgstr "存储池"
 
-#: templates/sidebar.html:21
+#: templates/servers.html:81 templates/sidebar.html:21
 msgid "Networks"
 msgstr "网络池"
 

--- a/templates/servers.html
+++ b/templates/servers.html
@@ -69,19 +69,19 @@
                             <td style="width:280px">
                                 <div class="btn-group btn-group-sm">
                                 {% ifequal host.status 1 %}
-                                    <a href="{% url 'instances' host.id %}" class="btn btn-primary">
+                                    <a href="{% url 'instances' host.id %}" class="btn btn-primary" title="{% trans "Instances" %}">
                                         <span class="glyphicon glyphicon-th-large"></span>
                                     </a>
-                                    <a href="{% url 'create' host.id %}" class="btn btn-primary">
+                                    <a href="{% url 'create' host.id %}" class="btn btn-primary" title="{% trans "Create" %}">
                                         <span class="glyphicon glyphicon-plus"></span>
                                     </a>
-                                    <a href="{% url 'storages' host.id %}" class="btn btn-primary">
+                                    <a href="{% url 'storages' host.id %}" class="btn btn-primary" title="{% trans "Storages" %}">
                                         <span class="glyphicon glyphicon-hdd"></span>
                                     </a>
-                                    <a href="{% url 'networks' host.id %}" class="btn btn-primary">
+                                    <a href="{% url 'networks' host.id %}" class="btn btn-primary" title="{% trans "Networks" %}">
                                         <span class="glyphicon glyphicon-globe"></span>
                                     </a>
-                                    <a href="{% url 'overview' host.id %}" class="btn btn-primary">
+                                    <a href="{% url 'overview' host.id %}" class="btn btn-primary" title="{% trans "Overview" %}">
                                         <span class="glyphicon glyphicon-info-sign"></span>
                                     </a>
                                 {% else %}
@@ -100,16 +100,16 @@
                                     <a href="#" class="btn btn-primary">
                                         <span class="glyphicon glyphicon-info-sign"></span>
                                     </a>
-                                </div>
                                 {% endifequal %}
+                                </div>
                             </td>
                             <td style="width:100px">
                                 <form action="" method="post">{% csrf_token %}
                                     <input type="hidden" name="host_id" value="{{ host.id }}">
-                                    <a data-toggle="modal" href="#editHost{{ host.id }}" class="btn btn-sm btn-primary" title="Edit">
+                                     <a data-toggle="modal" href="#editHost{{ host.id }}" class="btn btn-sm btn-primary" title="{% trans "Edit" %}">
                                         <span class="glyphicon glyphicon-pencil"></span>
                                     </a>
-                                    <button type="submit" class="btn btn-sm btn-danger" name="host_del" title="Delete" onclick="return confirm('{% trans "Are you sure?"%}')">
+                                    <button type="submit" class="btn btn-sm btn-danger" name="host_del" title="{% trans "Delete" %}" onclick="return confirm('{% trans "Are you sure?"%}')">
                                         <span class="glyphicon glyphicon-trash"></span>
                                     </button>
                                 </form>


### PR DESCRIPTION
This adds a title to all gui buttons on the main servers page.  Motivation behind this being that text shows what the button does on hover (it wasn't obvious when I first used the page).
