### PR TITLE
Add checkbox to allow live migration of VMs

### DIFF
--- a/instance/views.py
+++ b/instance/views.py
@@ -589,12 +589,13 @@ def instance(request, host_id, vname):
 
             if 'migrate' in request.POST:
                 compute_id = request.POST.get('compute_id', '')
+                live = request.POST.get('live_migrate', False)
                 new_compute = Compute.objects.get(id=compute_id)
                 conn_migrate = wvmInstances(new_compute.hostname,
                                             new_compute.login,
                                             new_compute.password,
                                             new_compute.type)
-                conn_migrate.moveto(conn, vname)
+                conn_migrate.moveto(conn, vname, live)
                 conn_migrate.define_move(vname)
                 conn_migrate.close()
                 return HttpResponseRedirect('/instance/%s/%s' % (compute_id, vname))

--- a/templates/instance.html
+++ b/templates/instance.html
@@ -596,6 +596,15 @@
                                     </select>
                                 </div>
                             </div>
+                            <div class="form-group">
+                                <div class="col-sm-offset-2 col-sm-10">
+                                    <div class="checkbox">
+                                        <label>
+                                            <input type="checkbox" name="live_migrate" value="true" id="vm_live_migrate">{% trans "Live Migration" %}
+                                        </label>
+                                    </div>
+                                </div>
+                            </div>
                             {% if computes_count != 1 %}
                                 <button type="submit" class="btn btn-lg btn-primary pull-right" name="migrate">{% trans "Migrate" %}</button>
                             {% else %}

--- a/vrtManager/instance.py
+++ b/vrtManager/instance.py
@@ -3,7 +3,7 @@
 #
 import time
 import os.path
-from libvirt import libvirtError, VIR_DOMAIN_XML_SECURE
+from libvirt import libvirtError, VIR_DOMAIN_XML_SECURE, VIR_MIGRATE_LIVE
 from vrtManager import util
 from xml.etree import ElementTree
 from datetime import datetime
@@ -65,9 +65,12 @@ class wvmInstances(wvmConnect):
         dom = self.get_instance(name)
         dom.resume()
 
-    def moveto(self, conn, name):
+    def moveto(self, conn, name, live):
+        flags = 0
+        if live and conn.get_status() == 1:
+            flags |= VIR_MIGRATE_LIVE
         dom = conn.get_instance(name)
-        dom.migrate(self.wvm, 0, name, None, 0)
+        dom.migrate(self.wvm, flags, name, None, 0)
 
     def define_move(self, name):
         dom = self.get_instance(name)


### PR DESCRIPTION
Adds functionality to allow live migration of running VMs.

I'm not a web designer (nor do I know the styling setup) so the check boxes' placement is not aligned properly on the page, but at least it's not in a terrible position.

If you have any suggestions on what to do on the template, please let me know.
