### PR TITLE
Skip over offline storage devices when mounting isos

### DIFF
--- a/vrtManager/instance.py
+++ b/vrtManager/instance.py
@@ -236,9 +236,10 @@ class wvmInstance(wvmConnect):
         storages = self.get_storages()
         for storage in storages:
             stg = self.get_storage(storage)
-            for img in stg.listVolumes():
-                if image == img:
-                    vol = stg.storageVolLookupByName(image)
+            if stg.info()[0] != 0:
+                for img in stg.listVolumes():
+                    if image == img:
+                        vol = stg.storageVolLookupByName(image)
         tree = ElementTree.fromstring(self._XMLDesc(0))
         for disk in tree.findall('devices/disk'):
             if disk.get('device') == 'cdrom':


### PR DESCRIPTION
When mounting ISOs via Instance > Settings > Media, was getting the following error that is telling me about an iSCSI pool that is not related to the VM I was changing:

`Requested operation is not valid: storage pool `vmpool-iscsi' is not active`

Tracked it down to the following area this pull request fixes, which tells `mount_iso` to skip over offlined storaged pools.

To reproduce, create a pool against a host, then stop it.  Then try and attach an ISO to a VM.  If you look at `get_iso_media` which retrieves the list of ISOs to available to mount, it does the same thing.
