### PR TITLE
New novnc websockify wrapper

### DIFF
--- a/console/webvirtmgr-novnc-new
+++ b/console/webvirtmgr-novnc-new
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+
+import os
+import sys
+
+DIR_PATH = os.path.dirname(os.path.abspath(__file__))
+ROOT_PATH = os.path.abspath(os.path.join(DIR_PATH, '..', ''))
+# VENV_PATH = ROOT_PATH + '/venv/lib/python2.7/site-packages'
+CERT = DIR_PATH + '/cert.pem'
+LISTEN_HOST = '0.0.0.0'
+LISTEN_PORT = '6080'
+
+if ROOT_PATH not in sys.path:
+    sys.path.append(ROOT_PATH)
+# if VENV_PATH not in sys.path:
+#     sys.path.append(VENV_PATH)
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "webvirtmgr.settings")
+
+import Cookie
+import socket
+import websockify as wsproxy
+
+
+class NovaProxyRequestHandler(wsproxy.ProxyRequestHandler):
+    def new_websocket_client(self):
+        """
+        Called after a new WebSocket connection has been established.
+        """
+
+        cookie = Cookie.SimpleCookie()
+        cookie.load(self.headers.getheader('cookie'))
+        token = cookie['token'].value
+
+        from instance.models import Instance
+        from vrtManager.instance import wvmInstance
+
+        try:
+            temptoken = token.split('-', 1)
+            host = int(temptoken[0])
+            uuid = temptoken[1]
+            instance = Instance.objects.get(compute_id=host, uuid=uuid)
+            conn = wvmInstance(instance.compute.hostname,
+                               instance.compute.login,
+                               instance.compute.password,
+                               instance.compute.type,
+                               instance.name)
+            self.server.target_port = conn.get_vnc()
+            self.server.target_host = instance.compute.hostname
+        except:
+            self.server.target_port = None
+            self.server.target_host = None
+
+        # Connect to the target
+        self.log_message("connecting to: %s:%s" % (self.server.target_host, self.server.target_port))
+        tsock = wsproxy.WebSocketServer.socket(self.server.target_host,
+                                               self.server.target_port,
+                                               connect=True,
+                                               use_ssl=self.server.ssl_target,
+                                               unix_socket=self.server.unix_target)
+
+        self.print_traffic(self.traffic_legend)
+
+        # Start proxying
+        try:
+            self.do_proxy(tsock)
+        except:
+            if tsock:
+                tsock.shutdown(socket.SHUT_RDWR)
+                tsock.close()
+                self.log_message("%s:%s: Target closed" % (self.server.target_host, self.server.target_port))
+            raise
+
+if __name__ == '__main__':
+    # Create and start the NovaWebSockets proxy
+    server = wsproxy.WebSocketProxy(RequestHandlerClass=NovaProxyRequestHandler,
+                                    listen_host=LISTEN_HOST,
+                                    listen_port=LISTEN_PORT,
+                                    source_is_ipv6=False,
+                                    verbose=True,
+                                    cert=CERT,
+                                    key=None,
+                                    ssl_only=False,
+                                    daemon=False,
+                                    record=False,
+                                    web=False,
+                                    target_host='ignore',
+                                    target_port='ignore',
+                                    wrap_mode='exit',
+                                    wrap_cmd=None)
+    server.start_server()


### PR DESCRIPTION
Added novnc proxy supporting new websockify versions

The websockify library starting from this commit:

https://github.com/kanaka/websockify/commit/7b3dd8a6f5ef26dbfd6c34a91600ea1613aefaa2

separates WebSocketProxy from the handler class

The `NovaWebSocketProxy` class defined in console/webvirtmgr-novnc inherit from `WebSocketProxy` and still seems to work but its `new_client` method never gets called.

This commit adds a new script that can be used with the new websockify library.
