### PR TITLE
adds support for ubuntu init script default file [/etc/default/webvirtmgr-novnc]

### DIFF
--- a/conf/initd/webvirtmgr-novnc-ubuntu
+++ b/conf/initd/webvirtmgr-novnc-ubuntu
@@ -13,25 +13,32 @@
 # PATH should only include /usr/* if it runs after the mountnfs.sh script
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 DESC="WebVirtMgr NoVNC proxy"
-NAME=webvirtmgr-novnc
-DAEMON=/var/www/webvirtmgr/console/webvirtmgr-novnc
-PIDFILE=/var/run/$NAME.pid
-SCRIPTNAME=/etc/init.d/$NAME
-LOCK_DIR=/var/lock/webvirtmgr/
+NAME='webvirtmgr-novnc'
+DAEMON_PREFIX='/var/www/webvirtmgr/console'
+PIDFILE="/run/${NAME}.pid"
+SCRIPTNAME="/etc/init.d/${NAME}"
+LOCK_DIR="/run/lock/${NAME}"
+USER='www-data'
+GROUP='www-data'
+
+# read in defaults if available
+[ -f "/etc/default/${NAME}" ] && . "/etc/default/${NAME}"
+
+DAEMON="${DAEMON_PREFIX}/${NAME}"
 
 # Exit if the package is not installed
 [ -x $DAEMON ] || exit 0
 
 mkdir -p ${LOCK_DIR}
-chown www-data ${LOCK_DIR}
+chown "${USER}:${GROUP}"  ${LOCK_DIR}
 
 . /lib/lsb/init-functions
 
 do_start()
 {
-	start-stop-daemon --start --background --quiet --chuid www-data:www-data --make-pidfile --pidfile $PIDFILE --startas $DAEMON --test > /dev/null \
+	start-stop-daemon --start --background --quiet --chuid "${USER}:${GROUP}" --make-pidfile --pidfile $PIDFILE --startas $DAEMON --test > /dev/null \
 		|| return 1
-	start-stop-daemon --start --background --quiet --chuid www-data:www-data --make-pidfile --pidfile $PIDFILE --startas $DAEMON -- \
+	start-stop-daemon --start --background --quiet --chuid "${USER}:${GROUP}" --make-pidfile --pidfile $PIDFILE --startas $DAEMON -- \
 		$DAEMON_ARGS \
 		|| return 2
 }


### PR DESCRIPTION
allows local settings for things like user/group to run as, location of daemon, etc - without needing to modify init script.

e.g.:

``` bash
>cat /etc/default/webvirtmgr-novnc
# Defaults for webvirtmgr-novnc init script
# sourced by /etc/init.d/webvirtmgr-novnc-ubuntu

#
# This is a POSIX shell fragment
#

# directory in which webvirtmgr-novnc is found
#DAEMON_PREFIX='/var/www/webvirtmgr/console'
DAEMON_PREFIX='/opt/webvirtmgr/console'

# user to run novnc as
#USER='www-data'
USER='webvirtmgr'

#GROUP='www-data'
GROUP='webvirtmgr'
```

also includes a few changes to adhere to ubuntu conventions for /run/, and some misc quoting and variable reuse modifications.
