### PR TITLE
Added checkbox to hide/show VMs based on current state

### DIFF
--- a/templates/infrastructure.html
+++ b/templates/infrastructure.html
@@ -6,6 +6,12 @@
         <div class="col-md-12" role="main">
             <div class="page-header">
                 <div class="input-append form-inline pull-right" style="">
+                    <div id="hide_vms_bystate" class="text-right">
+                        <span>Hide:</span>
+                        <label class="text-success"><input type="checkbox" data-value="1">{% trans "Running" %}</input></label>
+                        <label class="text-warning"><input type="checkbox" data-value="3">{% trans "Suspend" %}</input></label>
+                        <label class="text-danger"><input type="checkbox" data-value="5">{% trans "Shutoff" %}</input></label>
+                    </div>
                     <div class="form-group">
                         <input type="text" class="form-control" id="filter_input" style="margin-top:-28px;">
                     </div>
@@ -41,7 +47,7 @@
                         </tr>
                         {% if vms %}
                             {% for vm, info in vms.items %}
-                                <tr>
+                                <tr data-status="{{ info.0 }}">
                                     <td></td>
                                     <td>{{ forloop.counter }} &emsp; <a href="{% url 'instance' host.0 vm %}">{{ vm }}</a></td>
                                     <td>{% ifequal info.0 1 %}<span class="text-success">{% trans "Running" %}</span>{% endifequal %}

--- a/webvirtmgr/static/js/infrastructure.js
+++ b/webvirtmgr/static/js/infrastructure.js
@@ -32,4 +32,8 @@ $(document).ready(function() {
             $('#filter_button').click();
         }
     });
+
+    $('#hide_vms_bystate input[type=checkbox]').change(function () {
+	    $('tbody tr[data-status=' + $(this).data('value') + ']').toggle();
+    });
 });


### PR DESCRIPTION
Looking at comments on pull request https://github.com/retspen/webvirtmgr/pull/326, I decided to try to implement the checkbox way.

I added a set of checkboxes over the filter input that let you hide all the VMs in that state.
It just hides/shows rows on the client side via Javascript, it uses data- attributes to match states by number to be localization friendly.
