### PR TITLE
storage: correct usage calculation for rbd and add pool status

### DIFF
--- a/storages/views.py
+++ b/storages/views.py
@@ -91,6 +91,7 @@ def storage(request, host_id, pool):
             percent = (used * 100) / size
         else:
             percent = 0
+        status = conn.get_status()
         path = conn.get_target_path()
         type = conn.get_type()
         autostart = conn.get_autostart()

--- a/templates/storage.html
+++ b/templates/storage.html
@@ -25,6 +25,7 @@
                 <p>{% trans "Pool name" %}</p>
                 <p>{% trans "Pool type" %}</p>
                 <p>{% trans "Pool path" %}</p>
+                <p>{% trans "Pool status" %}</p>
                 <p>{% trans "Size" %} ({{ size|filesizeformat }} / {{ used|filesizeformat }})</p>
                 <p>{% trans "State" %}</p>
                 <p>{% trans "Autostart" %}</p>
@@ -41,6 +42,7 @@
                 </p>
                 <p>{% if not type %}{% trans "None" %}{% else %}{{ type }}{% endif %}</p>
                 <p>{% if not path %}{% trans "None" %}{% else %}{{ path }}{% endif %}</p>
+                <p>{% if not status %}{% trans "None" %}{% else %}{{ status }}{% endif %}</p>
                 <p>{% trans "Usage" %}: {{ percent }}%</p>
                 <p>
                     <form action="" method="post">{% csrf_token %}

--- a/vrtManager/storage.py
+++ b/vrtManager/storage.py
@@ -77,6 +77,13 @@ class wvmStorage(wvmConnect):
     def get_name(self):
         return self.pool.name()
 
+    def get_status(self):
+        status = ['Not running', 'Initializing pool, not available', 'Running normally', 'Running degraded']
+        try:
+            return status[self.pool.info()[0]]
+        except ValueError:
+            return 'Unknown'
+
     def get_size(self):
         return [self.pool.info()[1], self.pool.info()[3]]
 


### PR DESCRIPTION
I noticed a discrepancy in the reported used space for my ceph (rbd) cluster. The usage being report was off by approximately a factor of two. 

tyler@compute01:~$ sudo ceph -s
[sudo] password for tyler: 
    cluster 31845ace-9e1e-462e-bf15-76ed8a8dd851
     health HEALTH_OK
     monmap e8: 3 mons at {compute01=192.168.1.2:6789/0,compute02=192.168.1.3:6789/0,compute03=192.168.1.4:6789/0}, election epoch 976, quorum 0,1,2 compute01,compute02,compute03
     mdsmap e1570: 1/1/1 up {0=compute01=up:active}
     osdmap e1530: 14 osds: 14 up, 14 in
      pgmap v6444614: 384 pgs, 3 pools, 4708 GB data, 1183 kobjects
            9409 GB used, 27818 GB / 37228 GB avail
                 384 active+clean
  client io 3396 B/s wr, 1 op/s

(4708 GB \* 100) / 37228 GB = 12%
 it should be 
(9409 GB  \* 100) / 37228 GB = 25%

After some investigation I can conclude the following. get_size() returns size, free, usage. 'size' is the capacity of the pool, 'free' represents the allocation (4708 GB), but due to replication with rbd 'usage' actually reflects the available space of the pool  (37228 GB - 9409 GB). This is why I'm seeing the usage percentage discrepancy.

To fix this issue, I've modified get_size to return size (capacity) and free (amount of unused space). Then I simply calculate the used space by subtracting size from the amount of unused space. This yields the proper amount of used space for rbd, llvm, and dir storage pools.

I also added pool status for quickly identifying errors on storage clusters.

I've tested this patch with DIR, LLVM, and RBD storage pools and the reflected used space / usage percentage is correct for all variants.
