### PR TITLE
Fixes "TypeError: tostring() got an unexpected keyword argument 'method'"

### DIFF
--- a/vrtManager/instance.py
+++ b/vrtManager/instance.py
@@ -400,7 +400,7 @@ class wvmInstance(wvmConnect):
                 graphics_vnc.attrib.pop('passwd')
             except:
                 pass
-        newxml = ElementTree.tostring(root, encoding='utf-8', method='xml')
+        newxml = ElementTree.tostring(root)
         self._defineXML(newxml)
 
     def set_vnc_keymap(self, keymap):


### PR DESCRIPTION
Should fix the 500 error thrown when setting a VNC password.
