### PR TITLE
Add support for local socket connections

### DIFF
--- a/servers/forms.py
+++ b/servers/forms.py
@@ -146,3 +146,21 @@ class ComputeEditHostForm(forms.Form):
         elif wrong_ip:
             raise forms.ValidationError(_('Wrong IP address'))
         return hostname
+
+
+class ComputeAddSocketForm(forms.Form):
+    name = forms.CharField(error_messages={'required': _('No hostname has been entered')},
+                           max_length=20)
+
+    def clean_name(self):
+        name = self.cleaned_data['name']
+        have_symbol = re.match('[^a-zA-Z0-9._-]+', name)
+        if have_symbol:
+            raise forms.ValidationError(_('The host name must not contain any special characters'))
+        elif len(name) > 20:
+            raise forms.ValidationError(_('The host name must not exceed 20 characters'))
+        try:
+            Compute.objects.get(name=name)
+        except Compute.DoesNotExist:
+            return name
+        raise forms.ValidationError(_('This host is already connected'))

--- a/servers/views.py
+++ b/servers/views.py
@@ -4,9 +4,9 @@ from django.template import RequestContext
 
 from servers.models import Compute
 from instance.models import Instance
-from servers.forms import ComputeAddTcpForm, ComputeAddSshForm, ComputeEditHostForm, ComputeAddTlsForm
+from servers.forms import ComputeAddTcpForm, ComputeAddSshForm, ComputeEditHostForm, ComputeAddTlsForm, ComputeAddSocketForm
 from vrtManager.hostdetails import wvmHostDetails
-from vrtManager.connection import CONN_SSH, CONN_TCP, CONN_TLS, connection_manager
+from vrtManager.connection import CONN_SSH, CONN_TCP, CONN_TLS, CONN_SOCKET, connection_manager
 from libvirt import libvirtError
 
 
@@ -102,6 +102,18 @@ def servers_list(request):
                 compute_edit.login = data['login']
                 compute_edit.password = data['password']
                 compute_edit.save()
+                return HttpResponseRedirect(request.get_full_path())
+
+        if 'host_socket_add' in request.POST:
+            form = ComputeAddSocketForm(request.POST)
+            if form.is_valid():
+                data = form.cleaned_data
+                new_socket_host = Compute(name=data['name'],
+                                          hostname='localhost',
+                                          type=CONN_SOCKET,
+                                          login='',
+                                          password='')
+                new_socket_host.save()
                 return HttpResponseRedirect(request.get_full_path())
 
     return render_to_response('servers.html', locals(), context_instance=RequestContext(request))

--- a/templates/servers.html
+++ b/templates/servers.html
@@ -83,7 +83,8 @@
                             <p><strong>{% trans "Type" %}:</strong> [
                                 {% ifequal host.type 1 %}TCP{% endifequal %}
                                 {% ifequal host.type 2 %}SSH{% endifequal %}
-                                {% ifequal host.type 3 %}TLS{% endifequal %}]
+                                {% ifequal host.type 3 %}TLS{% endifequal %}
+                                {% ifequal host.type 4 %}SOCKET{% endifequal %} ]
                             </p>
 
                             <p><strong>{% trans "Host" %}:</strong> <a
@@ -100,6 +101,7 @@
                                                 {% ifequal host.type 1 %}({% trans "TCP" %}){% endifequal %}
                                                 {% ifequal host.type 2 %}({% trans "SSH" %}){% endifequal %}
                                                 {% ifequal host.type 3 %}({% trans "TLS" %}){% endifequal %}
+                                                {% ifequal host.type 4 %}({% trans "SOCKET" %}){% endifequal %}
                                             </h4>
                                         </div>
                                         <div class="tab-content">
@@ -265,6 +267,7 @@
                         </li>
                         <li><a href="#2" data-toggle="tab">{% trans "SSH Connections" %}</a></li>
                         <li><a href="#3" data-toggle="tab">{% trans "TLS Connection" %}</a></li>
+                        <li><a href="#4" data-toggle="tab">{% trans "Local Socket" %}</a></li>
                     </ul>
                 </div>
                 <div class="tab-content">
@@ -388,6 +391,24 @@
                                         data-dismiss="modal">{% trans "Close" %}</button>
                                 <button type="submit" class="btn btn-primary"
                                         name="host_tls_add">{% trans "Add" %}</button>
+                            </div>
+                        </form>
+                    </div>
+                    <div class="tab-pane" id="4">
+                        <form class="form-horizontal" method="post" role="form">{% csrf_token %}
+                            <div class="form-group">
+                                <label class="col-sm-4 control-label">{% trans "Label" %}</label>
+
+                                <div class="col-sm-6">
+                                    <input type="text" name="name" class="form-control" placeholder="Label Name"
+                                           maxlength="20" required pattern="[a-z0-9\.\-_]+">
+                                </div>
+                            </div>
+                           <div class="modal-footer">
+                                <button type="button" class="btn btn-default"
+                                        data-dismiss="modal">{% trans "Close" %}</button>
+                                <button type="submit" class="btn btn-primary"
+                                        name="host_socket_add">{% trans "Add" %}</button>
                             </div>
                         </form>
                     </div>

--- a/vrtManager/connection.py
+++ b/vrtManager/connection.py
@@ -13,6 +13,7 @@ from rwlock import ReadWriteLock
 from django.conf import settings
 
 
+CONN_SOCKET = 4
 CONN_TLS = 3
 CONN_SSH = 2
 CONN_TCP = 1
@@ -81,6 +82,8 @@ class wvmConnection(object):
                     self.__connect_ssh()
                 elif self.type == CONN_TLS:
                     self.__connect_tls()
+                elif self.type == CONN_SOCKET:
+                    self.__connect_socket()
                 else:
                     raise ValueError('"{type}" is not a valid connection type'.format(type=self.type))
 
@@ -174,6 +177,17 @@ class wvmConnection(object):
 
         try:
             self.connection = libvirt.openAuth(uri, auth, 0)
+            self.last_error = None
+
+        except libvirtError as e:
+            self.last_error = 'Connection Failed: ' + str(e)
+            self.connection = None
+
+    def __connect_socket(self):
+        uri = 'qemu:///system'
+
+        try:
+            self.connection = libvirt.open(uri)
             self.last_error = None
 
         except libvirtError as e:
@@ -442,5 +456,5 @@ class wvmConnect(object):
     def close(self):
         """Close connection"""
         # to-do: do not close connection ;)
-        #self.wvm.close()
+        # self.wvm.close()
         pass


### PR DESCRIPTION
This patch adds support for connecting to Libvirt via local socket.
In many cases users are running WebVirtMgr on the same system as
Libvirt, such as on an unRAID deployment. Connecting via local
socket works with "out of the box" Libvirt deployments and is easier
to configure for most users.
