### PR TITLE
Fix IPv6 gateway validation error message

### DIFF
--- a/interfaces/forms.py
+++ b/interfaces/forms.py
@@ -51,7 +51,7 @@ class AddInterface(forms.Form):
         if have_symbol:
             raise forms.ValidationError(_('The ipv6 gateway must not contain any special characters'))
         elif len(ipv6_gw) > 100:
-            raise forms.ValidationError(_('The ipv4 gateway must not exceed 1000 characters'))
+            raise forms.ValidationError(_('The ipv6 gateway must not exceed 100 characters'))
         return ipv6_gw
 
     def clean_name(self):


### PR DESCRIPTION
Creating an IPv6 gateway exceeding 100 characters produces an error message stating that IPv4 gateway interface must not exceed 1000 characters.
