### PR TITLE
fix an infinite loop when attaching an ISO to non-WebVirtMgr domain

### DIFF
--- a/vrtManager/instance.py
+++ b/vrtManager/instance.py
@@ -255,7 +255,7 @@ class wvmInstance(wvmConnect):
                             src_media = ElementTree.Element('source')
                             src_media.set('file', vol.path())
                             disk.insert(2, src_media)
-                            return
+                            return True
 
         storages = self.get_storages()
         for storage in storages:
@@ -266,7 +266,8 @@ class wvmInstance(wvmConnect):
                         vol = stg.storageVolLookupByName(image)
         tree = ElementTree.fromstring(self._XMLDesc(0))
         for disk in tree.findall('devices/disk'):
-            attach_iso(dev, disk, vol)
+            if attach_iso(dev, disk, vol):
+                break
         if self.get_status() == 1:
             xml = ElementTree.tostring(disk)
             self.instance.attachDevice(xml)


### PR DESCRIPTION
Infinite loop happens when domain XML is created outside of WebVirtMgr. WVM expects CD-ROM entry after hard drives.

Failing:

``` xml
    <disk type='file' device='cdrom'>
      <driver name='qemu' type='raw'/>
      <source file='/var/lib/libvirt/images/iso/archlinux-2014.09.03-dual.iso'/>
      <target dev='hda' bus='ide'/>
      <readonly/>
      <address type='drive' controller='0' bus='1' target='0' unit='1'/>
    </disk>
    <disk type='file' device='disk'>
      <driver name='qemu' type='qcow2'/>
      <source file='/var/lib/libvirt/images/ssd/5be1d57b-d5b1-4278-a807-d8dfefe3598a_vda.qcow2'/>
      <target dev='vda' bus='virtio'/>
      <address type='pci' domain='0x0000' bus='0x00' slot='0x04' function='0x0'/>
    </disk>
```

Working:

``` xml
    <disk type='file' device='disk'>
      <driver name='qemu' type='qcow2'/>
      <source file='/var/lib/libvirt/images/hdd/sdfsdfsdf.img'/>
      <target dev='vda' bus='virtio'/>
      <address type='pci' domain='0x0000' bus='0x00' slot='0x04' function='0x0'/>
    </disk>
    <disk type='file' device='cdrom'>
      <driver name='qemu' type='raw'/>
      <source file='/var/lib/libvirt/images/iso/FreeBSD-10.0-RELEASE-amd64-dvd1.iso'/>
      <target dev='hda' bus='ide'/>
      <readonly/>
      <address type='drive' controller='0' bus='1' target='0' unit='1'/>
    </disk>
```

This fixes it. Added a simple Python equivalent of [non-first level `break`](http://stackoverflow.com/a/189685/504845).
