### PR TITLE
force delete VM with existing snapshots

### DIFF
--- a/vrtManager/instance.py
+++ b/vrtManager/instance.py
@@ -3,7 +3,8 @@
 #
 import time
 import os.path
-from libvirt import libvirtError, VIR_DOMAIN_XML_SECURE, VIR_MIGRATE_LIVE, VIR_MIGRATE_UNSAFE
+from libvirt import libvirtError, VIR_DOMAIN_XML_SECURE, VIR_MIGRATE_LIVE, VIR_MIGRATE_UNSAFE, \
+    VIR_DOMAIN_UNDEFINE_SNAPSHOTS_METADATA
 from vrtManager import util
 from xml.etree import ElementTree
 from datetime import datetime
@@ -109,7 +110,7 @@ class wvmInstance(wvmConnect):
         self.instance.resume()
 
     def delete(self):
-        self.instance.undefine()
+        self.instance.undefineFlags(VIR_DOMAIN_UNDEFINE_SNAPSHOTS_METADATA)
 
     def _XMLDesc(self, flag):
         return self.instance.XMLDesc(flag)


### PR DESCRIPTION
> Requested operation is not valid: cannot delete inactive domain with 1 snapshots

Deleting the snapshots manually before being able to delete the VM doesn't much make sense. ;)

But what's more important, external snapshots (not supported by WVM itself) can't be deleted ([libvirt #1044691](https://bugzilla.redhat.com/show_bug.cgi?id=1044691#c11)). That said, it's inevitable to pass `VIR_DOMAIN_UNDEFINE_SNAPSHOTS_METADATA` to successfully delete a VM.