### PR TITLE
Sort instances by status then name directly in template

### DIFF
--- a/templates/instances.html
+++ b/templates/instances.html
@@ -29,7 +29,7 @@
                     </tr>
                     </thead>
                     <tbody>
-                    {% for inst in instances %}
+                    {% for inst in instances|dictsort:"name"|dictsort:"status" %}
                         <tr id="{{ inst.name }}">
                             <td><a href="{% url 'instance' host_id inst.name %}"><i
                                     class="icon-th-large"></i> {{ inst.name }}</a></td>


### PR DESCRIPTION
This PR completes work on #439 adding the default sort (by status then name) in the `instances.html` template. In some cases (Firefox on slow machine with lot of instances), before this, table is sorted after hundreds of milliseconds.; with this fix instances are already sorted in the right order.
