### PR TITLE
Random MAC address button in the clone view

### DIFF
--- a/templates/instance.html
+++ b/templates/instance.html
@@ -754,7 +754,7 @@
             }
         }
         function random_mac(net) {
-            var hexDigits = "0123456789ABCDEF";
+            var hexDigits = "0123456789abcdef";
             var macAddress="52:54:00:";
             for (var i=0; i<3; i++) {
                 macAddress+=hexDigits.charAt(Math.round(Math.random()*16));


### PR DESCRIPTION
This PR adds a button (for each interface) to generate a new, random MAC address in the clone view.

![screenshot from 2014-11-14 16 05 49](https://cloud.githubusercontent.com/assets/1818657/5047701/1e198dbc-6c18-11e4-8f79-2aaacb34770c.png)
