### PR TITLE
String substitution throws TypeError, preventing VNC SSH Tunnel

### DIFF
--- a/console/webvirtmgr-console
+++ b/console/webvirtmgr-console
@@ -107,10 +107,12 @@ class CompatibilityMixIn(object):
                          "one because it's not a SSH host")
                 raise
             try:
-                self.msg("Try to open tunnel on %s@%s:%s on console %s:%s " +
-                         "(or socket %s)" %
-                         (connuser, connhost, connport, console_host,
-                          console_port, console_socket))
+                # generate a string with all placeholders to avoid TypeErrors
+                # in sprintf
+                error_msg = "Try to open tunnel on %s@%s:%s on console %s:%s "
+                error_msg += "(or socket %s)"
+                self.msg(error_msg % (connuser, connhost, connport, console_host,
+                         console_port, console_socket))
                 tunnel = Tunnel()
                 fd = tunnel.open(connhost, connuser, connport,
                                  console_host, console_port, console_socket)

--- a/console/webvirtmgr-console
+++ b/console/webvirtmgr-console
@@ -109,6 +109,7 @@ class CompatibilityMixIn(object):
             try:
                 # generate a string with all placeholders to avoid TypeErrors
                 # in sprintf
+                # https://github.com/retspen/webvirtmgr/pull/497
                 error_msg = "Try to open tunnel on %s@%s:%s on console %s:%s "
                 error_msg += "(or socket %s)"
                 self.msg(error_msg % (connuser, connhost, connport, console_host,

--- a/console/webvirtmgr-console
+++ b/console/webvirtmgr-console
@@ -112,8 +112,8 @@ class CompatibilityMixIn(object):
                 # https://github.com/retspen/webvirtmgr/pull/497
                 error_msg = "Try to open tunnel on %s@%s:%s on console %s:%s "
                 error_msg += "(or socket %s)"
-                self.msg(error_msg % (connuser, connhost, connport, console_host,
-                         console_port, console_socket))
+                self.msg(error_msg % (connuser, connhost, connport,
+                         console_host, console_port, console_socket))
                 tunnel = Tunnel()
                 fd = tunnel.open(connhost, connuser, connport,
                                  console_host, console_port, console_socket)


### PR DESCRIPTION
Hi there,

I just came across an error regarding the noVNC console.
For security reasons, I only want VNC to listen on the loopback interface. In order to do so, I changed my connection type to SSH and set up authentication like described in the wiki.

However, I was unable to connect to the VMs Console via Webvirtmgr.
Skipping through the logs, I found the following exception:

```
WARNING:root:No local_settings file found.
WebSocket server settings:
  - Listen on 127.0.0.1:6080
  - Flash security policy server
  - SSL/TLS support
  - proxying from 127.0.0.1:6080 to ignore:ignore

...
  4: 127.0.0.1: Plain non-SSL (ws://) WebSocket connection
  4: 127.0.0.1: Version hybi-13, base64: 'False'
  4: Fail to open tunnel : not all arguments converted during string formatting
  4: handler exception: not all arguments converted during string formatting
  5: 127.0.0.1: Plain non-SSL (ws://) WebSocket connection
  5: 127.0.0.1: Version hybi-13, base64: 'False'
  5: Fail to open tunnel : not all arguments converted during string formatting
  5: handler exception: not all arguments converted during string formatting
^C  6: Got SIGINT, exiting
In SystemExit
```

Strangely, `not all arguments converted during string formatting` is a TypeError occuring during sprintf-like functions.
Digging into `console/webvirtmgr-console` I tracked the error back to the following block:

```python
                self.msg("Try to open tunnel on %s@%s:%s on console %s:%s " +
                         "(or socket %s)" %
                         (connuser, connhost, connport, console_host,
                          console_port, console_socket))
```
Unfortunately, string substitution won't work here. Python substitutes the placeholders first, connects the string afterwards. As a result, a TypeError is thrown because six variables are supplied for a string with only one placeholder.

I noticed you strictly use 80 chars per line at max, so my approach is to save the debug message into a variable `error_msg`, which will then be substituted with placeholders during the call to `self.msg`.

Feel free to change this however you think would be a better style. These are probably the only three lines of Python I've written in the last five years :wink: 

Cheers, :beers: 
Alexander