### PR TITLE
URL expression to use the Django URL dispatcher

### DIFF
--- a/console/views.py
+++ b/console/views.py
@@ -3,6 +3,7 @@ import re
 from django.shortcuts import render_to_response
 from django.template import RequestContext
 from django.http import HttpResponseRedirect
+from django.core.urlresolvers import reverse
 
 from instance.models import Instance
 from vrtManager.instance import wvmInstance
@@ -16,7 +17,7 @@ def console(request):
     Console instance block
     """
     if not request.user.is_authenticated():
-        return HttpResponseRedirect('/login')
+        return HttpResponseRedirect(reverse('login'))
 
     if request.method == 'GET':
         token = request.GET.get('token', '')

--- a/create/views.py
+++ b/create/views.py
@@ -2,6 +2,7 @@ from django.shortcuts import render_to_response
 from django.http import HttpResponseRedirect
 from django.template import RequestContext
 from django.utils.translation import ugettext_lazy as _
+from django.core.urlresolvers import reverse
 
 from servers.models import Compute
 from create.models import Flavor
@@ -19,7 +20,7 @@ def create(request, host_id):
     Create new instance.
     """
     if not request.user.is_authenticated():
-        return HttpResponseRedirect('/login')
+        return HttpResponseRedirect(reverse('login'))
 
     conn = None
     errors = []
@@ -79,7 +80,7 @@ def create(request, host_id):
                 else:
                     try:
                         conn._defineXML(xml)
-                        return HttpResponseRedirect('/instance/%s/%s' % (host_id, name))
+                        return HttpResponseRedirect(reverse('instance', args=[host_id, name]))
                     except libvirtError as err:
                         errors.append(err.message)
             if 'create' in request.POST:
@@ -127,7 +128,7 @@ def create(request, host_id):
                                                      uuid, volumes, data['networks'], data['virtio'], data['mac'])
                                 create_instance = Instance(compute_id=host_id, name=data['name'], uuid=uuid)
                                 create_instance.save()
-                                return HttpResponseRedirect('/instance/%s/%s/' % (host_id, data['name']))
+                                return HttpResponseRedirect(reverse('instance', args=[host_id, data['name']]))
                             except libvirtError as err:
                                 if data['hdd_size']:
                                     conn.delete_volume(volumes.keys()[0])

--- a/hostdetail/views.py
+++ b/hostdetail/views.py
@@ -3,6 +3,7 @@ from libvirt import libvirtError
 from django.shortcuts import render_to_response
 from django.http import HttpResponse, HttpResponseRedirect
 from django.template import RequestContext
+from django.core.urlresolvers import reverse
 import json
 import time
 
@@ -16,7 +17,7 @@ def hostusage(request, host_id):
     Return Memory and CPU Usage
     """
     if not request.user.is_authenticated():
-        return HttpResponseRedirect('/login')
+        return HttpResponseRedirect(reverse('login'))
 
     points = 5
     datasets = {}
@@ -105,7 +106,7 @@ def overview(request, host_id):
     Overview page.
     """
     if not request.user.is_authenticated():
-        return HttpResponseRedirect('/login')
+        return HttpResponseRedirect(reverse('login'))
 
     errors = []
     time_refresh = TIME_JS_REFRESH

--- a/instance/views.py
+++ b/instance/views.py
@@ -6,6 +6,7 @@ from django.shortcuts import render_to_response
 from django.http import HttpResponseRedirect, HttpResponse
 from django.template import RequestContext
 from django.utils.translation import ugettext_lazy as _
+from django.core.urlresolvers import reverse
 import json
 import time
 
@@ -23,7 +24,7 @@ def instusage(request, host_id, vname):
     Return instance usage
     """
     if not request.user.is_authenticated():
-        return HttpResponseRedirect('/login')
+        return HttpResponseRedirect(reverse('login'))
 
     cookies = {}
     datasets = {}
@@ -263,7 +264,7 @@ def insts_status(request, host_id):
     Instances block
     """
     if not request.user.is_authenticated():
-        return HttpResponseRedirect('/login')
+        return HttpResponseRedirect(reverse('login'))
 
     errors = []
     instances = []
@@ -300,7 +301,7 @@ def instances(request, host_id):
     Instances block
     """
     if not request.user.is_authenticated():
-        return HttpResponseRedirect('/login')
+        return HttpResponseRedirect(reverse('login'))
 
     errors = []
     instances = []
@@ -371,7 +372,7 @@ def instance(request, host_id, vname):
     Instance block
     """
     if not request.user.is_authenticated():
-        return HttpResponseRedirect('/login')
+        return HttpResponseRedirect(reverse('login'))
 
     def show_clone_disk(disks):
         clone_disk = []
@@ -478,7 +479,7 @@ def instance(request, host_id, vname):
                         conn.delete_disk()
                 finally:
                     conn.delete()
-                return HttpResponseRedirect('/instances/%s/' % host_id)
+                return HttpResponseRedirect(reverse('instances', args=[host_id]))
             if 'snapshot' in request.POST:
                 name = request.POST.get('name', '')
                 conn.create_snapshot(name)
@@ -563,7 +564,7 @@ def instance(request, host_id, vname):
                 conn_migrate.moveto(conn, vname, live, unsafe, xml_del)
                 conn_migrate.define_move(vname)
                 conn_migrate.close()
-                return HttpResponseRedirect('/instance/%s/%s' % (compute_id, vname))
+                return HttpResponseRedirect(reverse('instance', args=[compute_id, vname]))
             if 'delete_snapshot' in request.POST:
                 snap_name = request.POST.get('name', '')
                 conn.snapshot_delete(snap_name)
@@ -583,7 +584,7 @@ def instance(request, host_id, vname):
                         clone_data[post] = request.POST.get(post, '')
 
                 conn.clone_instance(clone_data)
-                return HttpResponseRedirect('/instance/%s/%s' % (host_id, clone_data['name']))
+                return HttpResponseRedirect(reverse('instance', args=[host_id, clone_data['name']]))
 
         conn.close()
 

--- a/interfaces/views.py
+++ b/interfaces/views.py
@@ -1,6 +1,7 @@
 from django.shortcuts import render_to_response
 from django.http import HttpResponseRedirect
 from django.template import RequestContext
+from django.core.urlresolvers import reverse
 
 from servers.models import Compute
 from interfaces.forms import AddInterface
@@ -16,7 +17,7 @@ def interfaces(request, host_id):
 
     """
     if not request.user.is_authenticated():
-        return HttpResponseRedirect('/')
+        return HttpResponseRedirect(reverse('index'))
 
     errors = []
     ifaces_all = []
@@ -59,7 +60,7 @@ def interface(request, host_id, iface):
 
     """
     if not request.user.is_authenticated():
-        return HttpResponseRedirect('/')
+        return HttpResponseRedirect(reverse('index'))
 
     errors = []
     ifaces_all = []
@@ -90,7 +91,7 @@ def interface(request, host_id, iface):
                 return HttpResponseRedirect(request.get_full_path())
             if 'delete' in request.POST:
                 conn.delete_iface()
-                return HttpResponseRedirect('/interfaces/%s' % host_id)
+                return HttpResponseRedirect(reverse('interfaces', args=[host_id]))
         conn.close()
     except libvirtError as err:
         errors.append(err)

--- a/networks/views.py
+++ b/networks/views.py
@@ -2,6 +2,7 @@ from django.shortcuts import render_to_response
 from django.http import HttpResponseRedirect
 from django.template import RequestContext
 from django.utils.translation import ugettext_lazy as _
+from django.core.urlresolvers import reverse
 
 from servers.models import Compute
 from networks.forms import AddNetPool
@@ -17,7 +18,7 @@ def networks(request, host_id):
     Networks block
     """
     if not request.user.is_authenticated():
-        return HttpResponseRedirect('/login')
+        return HttpResponseRedirect(reverse('login'))
 
     errors = []
     compute = Compute.objects.get(id=host_id)
@@ -47,7 +48,7 @@ def networks(request, host_id):
                     if not errors:
                         conn.create_network(data['name'], data['forward'], gateway, netmask,
                                             dhcp, data['bridge_name'], data['openvswitch'], data['fixed'])
-                        return HttpResponseRedirect('/network/%s/%s/' % (host_id, data['name']))
+                        return HttpResponseRedirect(reverse('network', args=[host_id, data['name']]))
         conn.close()
     except libvirtError as err:
         errors.append(err)
@@ -60,7 +61,7 @@ def network(request, host_id, pool):
     Networks block
     """
     if not request.user.is_authenticated():
-        return HttpResponseRedirect('/login')
+        return HttpResponseRedirect(reverse('login'))
 
     errors = []
     compute = Compute.objects.get(id=host_id)
@@ -99,7 +100,7 @@ def network(request, host_id, pool):
         if 'delete' in request.POST:
             try:
                 conn.delete()
-                return HttpResponseRedirect('/networks/%s/' % host_id)
+                return HttpResponseRedirect(reverse('networks', args=[host_id]))
             except libvirtError as error_msg:
                 errors.append(error_msg.message)
         if 'set_autostart' in request.POST:

--- a/secrets/views.py
+++ b/secrets/views.py
@@ -1,6 +1,7 @@
 from django.shortcuts import render_to_response
 from django.http import HttpResponseRedirect
 from django.template import RequestContext
+from django.core.urlresolvers import reverse
 
 from servers.models import Compute
 from secrets.forms import AddSecret
@@ -15,7 +16,7 @@ def secrets(request, host_id):
     Networks block
     """
     if not request.user.is_authenticated():
-        return HttpResponseRedirect('/login')
+        return HttpResponseRedirect(reverse('login'))
 
     errors = []
     secrets_all = []

--- a/servers/views.py
+++ b/servers/views.py
@@ -1,6 +1,7 @@
 from django.shortcuts import render_to_response
 from django.http import HttpResponseRedirect
 from django.template import RequestContext
+from django.core.urlresolvers import reverse
 
 from servers.models import Compute
 from instance.models import Instance
@@ -17,9 +18,9 @@ def index(request):
 
     """
     if not request.user.is_authenticated():
-        return HttpResponseRedirect('/login')
+        return HttpResponseRedirect(reverse('login'))
     else:
-        return HttpResponseRedirect('/servers')
+        return HttpResponseRedirect(reverse('servers_list'))
 
 
 def servers_list(request):
@@ -27,7 +28,7 @@ def servers_list(request):
     Servers page.
     """
     if not request.user.is_authenticated():
-        return HttpResponseRedirect('/login')
+        return HttpResponseRedirect(reverse('login'))
 
     def get_hosts_status(hosts):
         """
@@ -124,7 +125,7 @@ def infrastructure(request):
     Infrastructure page.
     """
     if not request.user.is_authenticated():
-        return HttpResponseRedirect('/login')
+        return HttpResponseRedirect(reverse('login'))
 
     compute = Compute.objects.filter()
     hosts_vms = {}

--- a/storages/views.py
+++ b/storages/views.py
@@ -2,6 +2,7 @@ from django.shortcuts import render_to_response
 from django.http import HttpResponseRedirect
 from django.template import RequestContext
 from django.utils.translation import ugettext_lazy as _
+from django.core.urlresolvers import reverse
 
 from servers.models import Compute
 from storages.forms import AddStgPool, AddImage, CloneImage
@@ -16,7 +17,7 @@ def storages(request, host_id):
     Storage pool block
     """
     if not request.user.is_authenticated():
-        return HttpResponseRedirect('/login')
+        return HttpResponseRedirect(reverse('login'))
 
     errors = []
     compute = Compute.objects.get(id=host_id)
@@ -55,7 +56,7 @@ def storages(request, host_id):
                                                       data['source_format'], data['target'])
                         else:
                             conn.create_storage(data['stg_type'], data['name'], data['source'], data['target'])
-                        return HttpResponseRedirect('/storage/%s/%s/' % (host_id, data['name']))
+                        return HttpResponseRedirect(reverse('storage', args=[host_id, data['name']]))
         conn.close()
     except libvirtError as err:
         errors.append(err)
@@ -68,7 +69,7 @@ def storage(request, host_id, pool):
     Storage pool block
     """
     if not request.user.is_authenticated():
-        return HttpResponseRedirect('/login')
+        return HttpResponseRedirect(reverse('login'))
 
     def handle_uploaded_file(path, f_name):
         target = path + '/' + str(f_name)
@@ -125,7 +126,7 @@ def storage(request, host_id, pool):
         if 'delete' in request.POST:
             try:
                 conn.delete()
-                return HttpResponseRedirect('/storages/%s/' % host_id)
+                return HttpResponseRedirect(reverse('storages', args=[host_id]))
             except libvirtError as error_msg:
                 errors.append(error_msg.message)
         if 'set_autostart' in request.POST:

--- a/templates/base.html
+++ b/templates/base.html
@@ -19,7 +19,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a class="navbar-brand" href="/">WebVirtMgr</a>
+            <a class="navbar-brand" href="{% url 'index' %}">WebVirtMgr</a>
         </div>
         <div class="collapse navbar-collapse">
             <ul class="nav navbar-nav">

--- a/templates/base_auth.html
+++ b/templates/base_auth.html
@@ -19,7 +19,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a class="navbar-brand" href="/">WebVirtMgr</a>
+            <a class="navbar-brand" href="{% url 'index' %}">WebVirtMgr</a>
         </div>
         <div class="collapse navbar-collapse">
             <ul class="nav navbar-nav navbar-right">

--- a/templates/login.html
+++ b/templates/login.html
@@ -15,7 +15,7 @@
                 <input type="text" class="form-control" name="username" placeholder="Login" autocapitalize="none"
                        autocorrect="off" autofocus>
                 <input type="password" class="form-control" name="password" placeholder="Password">
-                <input name="next" id="next" type="hidden" value="/servers/">
+                <input name="next" id="next" type="hidden" value="{% url 'servers_list' %}">
                 <button class="btn btn-lg btn-success btn-block" type="submit">{% trans "Sign In" %}</button>
             </form>
         </div>


### PR DESCRIPTION
Modified URL expression to use the Django URL dispatcher.

Expected uses:

Install the WebVirtMgr inside reverse proxy, and think the situation that access the all (exclude the noVNC) resources used subdirectory path.
(e.g. http://example.com/webvirtmgr/instances/1/)

Then add configuration the below, and work under the subdirectory.
```
$ cat webvirtmgr/local/local_settings.py
STATIC_URL = '/webvirtmgr/static/'
FORCE_SCRIPT_NAME='/webvirtmgr'
```