### PR TITLE
Fix LVM device validation

### DIFF
--- a/storages/forms.py
+++ b/storages/forms.py
@@ -42,7 +42,7 @@ class AddStgPool(forms.Form):
     def clean_source(self):
         storage_type = self.cleaned_data['stg_type']
         source = self.cleaned_data['source']
-        have_symbol = re.match('^[a-zA-Z0-9\/]+$', source)
+        have_symbol = re.match('^[a-zA-Z0-9\/_]+$', source)
         if storage_type == 'logical' or storage_type == 'netfs':
             if not source:
                 raise forms.ValidationError(_('No device has been entered'))

--- a/templates/storages.html
+++ b/templates/storages.html
@@ -143,7 +143,7 @@
 
                                 <div class="col-sm-6">
                                     <input type="text" class="form-control" name="source" value="/dev/sdb" required
-                                           pattern="[a-z0-9\/]+">
+                                           pattern="[a-z0-9\/_]+">
                                 </div>
                             </div>
                             <div class="modal-footer">

--- a/vrtManager/instance.py
+++ b/vrtManager/instance.py
@@ -5,7 +5,7 @@ import time
 import os.path
 try:
     from libvirt import libvirtError, VIR_DOMAIN_XML_SECURE, VIR_MIGRATE_LIVE, \
-                        VIR_MIGRATE_UNSAFE, VIR_DOMAIN_UNDEFINE_SNAPSHOTS_METADATA
+        VIR_MIGRATE_UNSAFE, VIR_DOMAIN_UNDEFINE_SNAPSHOTS_METADATA
 except:
     from libvirt import libvirtError, VIR_DOMAIN_XML_SECURE, VIR_MIGRATE_LIVE
 from vrtManager import util


### PR DESCRIPTION
Hi,

When using disks in a RAID, disks name such as `/dev/mapper/isw_dhbbdjjcfb_system3`,
which failed validation while being correct. I made a small change to the validation regex to allow underscores.

I also fixed the file making the build fail due to pep8 warning.