### PR TITLE
add support for backingStore clone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ webvirtmgr/local/.secret_key_store
 webvirtmgr/local/local_settings.py
 dist
 webvirtmgr.egg-info
+/static

--- a/create/forms.py
+++ b/create/forms.py
@@ -44,6 +44,7 @@ class NewVMForm(forms.Form):
     images = forms.CharField(required=False)
     hdd_size = forms.IntegerField(required=False)
     meta_prealloc = forms.BooleanField(required=False)
+    meta_base = forms.BooleanField(required=False)
     virtio = forms.BooleanField(required=False)
     mac = forms.CharField(required=False)
 

--- a/create/views.py
+++ b/create/views.py
@@ -27,6 +27,7 @@ def create(request, host_id):
     storages = []
     networks = []
     meta_prealloc = False
+    meta_base = False
     compute = Compute.objects.get(id=host_id)
     flavors = Flavor.objects.filter().order_by('id')
 
@@ -90,6 +91,8 @@ def create(request, host_id):
                     data = form.cleaned_data
                     if data['meta_prealloc']:
                         meta_prealloc = True
+                    if data['meta_base']:
+                        meta_base = True
                     if instances:
                         if data['name'] in instances:
                             msg = _("A virtual machine with this name already exists")
@@ -108,7 +111,7 @@ def create(request, host_id):
                                     errors.append(msg_error.message)
                         elif data['template']:
                             templ_path = conn.get_volume_path(data['template'])
-                            clone_path = conn.clone_from_template(data['name'], templ_path, metadata=meta_prealloc)
+                            clone_path = conn.clone_from_template(data['name'], templ_path, metadata=meta_prealloc, meta_base=meta_base)
                             volumes[clone_path] = conn.get_volume_type(clone_path)
                         else:
                             if not data['images']:

--- a/templates/create.html
+++ b/templates/create.html
@@ -422,7 +422,15 @@
                         <div class="col-sm-6">
                             <input type="checkbox" name="meta_prealloc" title="Metadata preallocation" value="true">
                         </div>
-                        <label class="col-lg-1 control-label">{% trans "Image" %}</label>
+                        <label class="col-lg-1 control-label">{% trans "Prealloc" %}</label>
+                    </div>
+                    <div class="form-group meta-base">
+                        <label class="col-sm-3 control-label">{% trans "Use basefile" %}</label>
+
+                        <div class="col-sm-6">
+                            <input type="checkbox" name="meta_base" title="Use basefile for allocation" value="true">
+                        </div>
+                        <label class="col-lg-1 control-label">{% trans "Basefile" %}</label>
                     </div>
                     <div class="form-group">
                         <label class="col-sm-3 control-label">{% trans "Network" %}</label>

--- a/vrtManager/create.py
+++ b/vrtManager/create.py
@@ -105,8 +105,8 @@ class wvmCreate(wvmConnect):
         format = util.get_xml_path(vol.XMLDesc(0), "/volume/target/format/@type")
         metadata = kwargs.get('metadata', False)
         capacity = 0
+        capacity_unit = util.get_xml_path(vol.XMLDesc(0), "/volume/capacity/@unit")
         meta_base = kwargs.get('meta_base', False)
-        vol_info = util.probe_img_info(vol.path())
         if storage_type == 'dir':
             clone += '.img'
         else:
@@ -121,8 +121,8 @@ class wvmCreate(wvmConnect):
             v_tree.append(E.backingStore(
                 E.path(vol.path()),
                 E.format(type=format)))
-            capacity = vol_info.get('virtual-size', 0)
-        v_tree.append(E.capacity(str(capacity), unit='G'))
+            capacity = util.get_xml_path(vol.XMLDesc(0), "/volume/capacity")
+        v_tree.append(E.capacity(str(capacity), unit=capacity_unit))
         v_tree.append(target)
         xml = etree.tostring(v_tree)
         stg.createXML(xml, metadata)

--- a/vrtManager/util.py
+++ b/vrtManager/util.py
@@ -5,8 +5,6 @@ import re
 import random
 import libxml2
 import libvirt
-import subprocess
-import json
 
 
 def is_kvm_available(xml):
@@ -129,17 +127,3 @@ def pretty_bytes(val):
         return "%2.2f GB" % (val / (1024.0 * 1024.0 * 1024.0))
     else:
         return "%2.2f MB" % (val / (1024.0 * 1024.0))
-
-
-def probe_img_info(path):
-    cmd = ["qemu-img", "info", "--output=json", path]
-    info = dict()
-    try:
-        p = subprocess.Popen(cmd, stdout=subprocess.PIPE)
-        out, err = p.communicate()
-    except:
-        return info
-    info = json.loads(out)
-    info['virtual-size'] = info['virtual-size'] >> 30
-    info['actual-size'] = info['actual-size'] >> 30
-    return info

--- a/vrtManager/util.py
+++ b/vrtManager/util.py
@@ -130,6 +130,7 @@ def pretty_bytes(val):
     else:
         return "%2.2f MB" % (val / (1024.0 * 1024.0))
 
+
 def probe_img_info(path):
     cmd = ["qemu-img", "info", "--output=json", path]
     info = dict()

--- a/vrtManager/util.py
+++ b/vrtManager/util.py
@@ -5,6 +5,8 @@ import re
 import random
 import libxml2
 import libvirt
+import subprocess
+import json
 
 
 def is_kvm_available(xml):
@@ -127,3 +129,16 @@ def pretty_bytes(val):
         return "%2.2f GB" % (val / (1024.0 * 1024.0 * 1024.0))
     else:
         return "%2.2f MB" % (val / (1024.0 * 1024.0))
+
+def probe_img_info(path):
+    cmd = ["qemu-img", "info", "--output=json", path]
+    info = dict()
+    try:
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+        out, err = p.communicate()
+    except:
+        return info
+    info = json.loads(out)
+    info['virtual-size'] = info['virtual-size'] >> 30
+    info['actual-size'] = info['actual-size'] >> 30
+    return info


### PR DESCRIPTION
This PR implement new option 'base' for creating new instance from template
With this option volume for new instance create with 'backing file' to parent instance. 'backing file' reduce disk usage in pool.
See more https://libvirt.org/formatstorage.html#StorageVolBacking