### PR TITLE
Don't hide ISOs with uppercase names

### DIFF
--- a/vrtManager/instance.py
+++ b/vrtManager/instance.py
@@ -532,7 +532,7 @@ class wvmInstance(wvmConnect):
                 except:
                     pass
                 for img in stg.listVolumes():
-                    if img.endswith('.iso'):
+                    if img.lower().endswith('.iso'):
                         iso.append(img)
         return iso
 


### PR DESCRIPTION
Most Microsoft ISOs are distributed by default with the extension being in upper-case, while most *nix ISOs are lower-case.  For a brief moment I thought the code was inhabited by an evil Microsoft-hating spirit... ;)