### PR TITLE
Properly parse the capabilities XML to confirm KVM support

### DIFF
--- a/vrtManager/util.py
+++ b/vrtManager/util.py
@@ -8,8 +8,8 @@ import libvirt
 
 
 def is_kvm_available(xml):
-    capabilites = re.search('kvm', xml)
-    if capabilites:
+    kvm_domains = get_xml_path(xml, "//domain/@type='kvm'")
+    if kvm_domains > 0:
         return True
     else:
         return False

--- a/vrtManager/util.py
+++ b/vrtManager/util.py
@@ -1,7 +1,6 @@
 #
 # Copyright (C) 2013 Webvirtmgr.
 #
-import re
 import random
 import libxml2
 import libvirt


### PR DESCRIPTION
I was using webvirtmgr on an old piece of hardware that didnt have KVM support, but the word "kvm" appeared in the capabilities XML so I was unable to create a new instance as this function was determining I had KVM available.

I've used one of the helper methods in utils to parse the XML for the domain/type section instead. This works on my non-KVM box and my newer KVM-capable machine, though it could do with wider testing.