### PR TITLE
Fix novnc mouse on chrome

### DIFF
--- a/webvirtmgr/static/js/novnc/input.js
+++ b/webvirtmgr/static/js/novnc/input.js
@@ -635,14 +635,14 @@ that.grab = function() {
         Util.addEvent(window, 'touchend', onMouseUp);
         Util.addEvent(c, 'touchend', onMouseUp);
         Util.addEvent(c, 'touchmove', onMouseMove);
-    } else {
-        Util.addEvent(c, 'mousedown', onMouseDown);
-        Util.addEvent(window, 'mouseup', onMouseUp);
-        Util.addEvent(c, 'mouseup', onMouseUp);
-        Util.addEvent(c, 'mousemove', onMouseMove);
-        Util.addEvent(c, (Util.Engine.gecko) ? 'DOMMouseScroll' : 'mousewheel',
-                onMouseWheel);
     }
+
+	Util.addEvent(c, 'mousedown', onMouseDown);
+	Util.addEvent(window, 'mouseup', onMouseUp);
+	Util.addEvent(c, 'mouseup', onMouseUp);
+	Util.addEvent(c, 'mousemove', onMouseMove);
+	Util.addEvent(c, (Util.Engine.gecko) ? 'DOMMouseScroll' : 'mousewheel',
+			onMouseWheel);
 
     /* Work around right and middle click browser behaviors */
     Util.addEvent(document, 'click', onMouseDisable);
@@ -660,14 +660,14 @@ that.ungrab = function() {
         Util.removeEvent(window, 'touchend', onMouseUp);
         Util.removeEvent(c, 'touchend', onMouseUp);
         Util.removeEvent(c, 'touchmove', onMouseMove);
-    } else {
-        Util.removeEvent(c, 'mousedown', onMouseDown);
-        Util.removeEvent(window, 'mouseup', onMouseUp);
-        Util.removeEvent(c, 'mouseup', onMouseUp);
-        Util.removeEvent(c, 'mousemove', onMouseMove);
-        Util.removeEvent(c, (Util.Engine.gecko) ? 'DOMMouseScroll' : 'mousewheel',
-                onMouseWheel);
     }
+
+	Util.removeEvent(c, 'mousedown', onMouseDown);
+	Util.removeEvent(window, 'mouseup', onMouseUp);
+	Util.removeEvent(c, 'mouseup', onMouseUp);
+	Util.removeEvent(c, 'mousemove', onMouseMove);
+	Util.removeEvent(c, (Util.Engine.gecko) ? 'DOMMouseScroll' : 'mousewheel',
+			onMouseWheel);
 
     /* Work around right and middle click browser behaviors */
     Util.removeEvent(document, 'click', onMouseDisable);


### PR DESCRIPTION
I think chrome(new version) has 'ontouchstart' by default.
So mouse event does not work.

If problem has occur on other engine(like gecko), some other patch needed.
(Tested on IE, Chrome, Android AOSP browser)