### PR TITLE
add hdd cache to create from flavor

### DIFF
--- a/templates/create.html
+++ b/templates/create.html
@@ -123,6 +123,17 @@
                                                         </select>
                                                     </div>
                                                 </div>
+                                                <div class="form-group">
+                                                    <label class="col-sm-3 control-label">{% trans "HDD cache mode" %}</label>
+
+                                                    <div class="col-sm-6">
+                                                        <select id="cache_mode" name="cache_mode" class="form-control">
+                                                            {% for mode, name in cache_modes %}
+                                                                <option value="{{ mode }}">{% trans name %}</option>
+                                                            {% endfor %}
+                                                        </select>
+                                                    </div>
+                                                </div>
                                                 <div class="form-group meta-prealloc">
                                                     <label class="col-sm-3 control-label">{% trans "Metadata" %}</label>
 


### PR DESCRIPTION
Creating an instance from a flavor fails as the create form is missing the hdd cache option. This causes the form to be marked as invalid and the operation fails. 

This PR adds the missing form element - it's copied over from the other forms present in the create template. 