### PR TITLE
Don't add port 22 to default

### DIFF
--- a/console/webvirtmgr-console
+++ b/console/webvirtmgr-console
@@ -127,7 +127,7 @@ def get_connection_infos(token):
             connport = instance.compute.hostname.split(':')[1]
         else:
             connhost = instance.compute.hostname
-            connport = 22
+            connport = None
         connuser = instance.compute.login
         conntype = instance.compute.type
         console_host = conn.get_console_listen_addr()


### PR DESCRIPTION
Specifying the port seems unnecessary since the ssh commandline
tool will use the correct port if specified. Specifying it here
can also cause problems if the host is an SSH alias where the port
is already defined.

I'm using webvirtmgr this way to manage hypervisors accessed through
an SSH tunnel.